### PR TITLE
Fix esbmc command

### DIFF
--- a/lsverifier/__init__.py
+++ b/lsverifier/__init__.py
@@ -8,6 +8,17 @@ from lsverifier.bar import Bar
 from lsverifier.utils import utils
 from lsverifier.utils import shell
 
+class colors:
+    RESET = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+    RED = '\033[91m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    BLUE = '\033[94m'
+    MAGENTA = '\033[95m'
+    CYAN = '\033[96m'
+
 class NewLineHelpFormatter(argparse.HelpFormatter):
     def _split_lines(self, text, width):
         if text.startswith('Properties to be verified'):
@@ -63,7 +74,7 @@ def arguments():
     parser.add_argument("-v", "--verbose", help="Enable Verbose Output", action="store_true", default=False)
     parser.add_argument("-r", "--recursive", help="Enable Recursive Verification", action="store_true", default=False)
     parser.add_argument("-d", "--directory", help="Set the directory to be verified", default=False)
-    parser.add_argument("-dp", "--disable-pointer-check", help="Disable invalid pointer property verification", action="store_true", default=False)
+    parser.add_argument("-dp", "--disable-pointer-check", help="Disable invalid pointer verification", action="store_true", default=False)
     parser.add_argument("-e", "--esbmc-parameter", help="Use ESBMC parameter")
 
     args = parser.parse_args()
@@ -82,14 +93,13 @@ def main():
     tracemalloc.start()
 
     args = arguments()
-    print("LSVerifier is loading...")
+    print("[LSVerifier] Loading configuration settings")
 
-    print("Setting the verification parameters...")
     log_name = log.configure(args.verbose)
 
     # Check if both -f and -fp are given
     if args.functions and args.function_prioritized:
-        print("Error: Cannot use both -f and -fp options at the same time.")
+        print(colors.RED + "[LSVerifier] Error: Conflicting options -f and -fp used together" + colors.RESET)
         return 1  # exit with an error code
 
     cmd_line = utils.get_command_line(args)
@@ -116,7 +126,7 @@ def main():
 
     start_all = time.time()
 
-    print("Running ESBMC module verification...")
+    print("[LSVerifier] Running ESBMC model checker")
     n_func = 0
     pbar = Bar(all_c_files, verbose=args.verbose)
     for c_file in pbar:
@@ -135,7 +145,7 @@ def main():
     log.summary(len(all_c_files), n_func, len(cex_list), elapsed_all, peak)
 
     csvwr.export_cex(cex_list, log_name)
-    print("LSVerifier - Verification is complete.")
+    print(colors.GREEN + "[LSVerifier] Verification completed" + colors.RESET)
 
 if __name__ == "__main__":
     main()

--- a/lsverifier/utils/shell.py
+++ b/lsverifier/utils/shell.py
@@ -60,11 +60,11 @@ def run_esbmc(c_file, cmd_line, dep_list, args):
     for func in func_list:
         log.header(c_file, esbmc_args, func)
 
-        cmd = ([esbmc_path, c_file] +
-                ([] if not args.functions else [FUNCTION, func]) +
-                dep_list +
-                esbmc_args)
+        cmd = [esbmc_path, c_file] + dep_list + esbmc_args
 
+        if args.functions or args.function_prioritized:
+            cmd += [FUNCTION, func]
+        
         fail = run(cmd)
 
         if args.disable_pointer_check:


### PR DESCRIPTION
The `--function` argument was not being passed to ESBMC when the user invoked LSVerifier with the `--function-prioritized` option